### PR TITLE
Mostly bug fixes

### DIFF
--- a/aioircd.py
+++ b/aioircd.py
@@ -151,7 +151,14 @@ class User:
 
     async def serve(self):
         buffer = b""
-        while chunk := await self.reader.read(1024):
+        while True:
+            try:
+                chunk = await self.reader.read(1024)
+            except ConnectionResetError:
+                break
+            if not chunk:
+                break
+
             buffer += chunk
             *lines, buffer = buffer.split(b'\r\n')
 

--- a/aioircd.py
+++ b/aioircd.py
@@ -30,9 +30,10 @@ def main():
     logging.root.handlers.clear()
     logging.root.addHandler(stdout)
     logging.root.setLevel(verbosity)
-    logging.addLevelName(logging.INFO, 'MSG')
-    logging.msg = functools.partial(logging.log, 'MSG')
-    logger.msg = functools.partial(logger.log, 'MSG')
+    logging.MSG = logging.INFO + 1
+    logging.addLevelName(logging.MSG, 'MSG')
+    logging.msg = functools.partial(logging.log, logging.MSG)
+    logger.msg = functools.partial(logger.log, logging.MSG)
 
     if verbosity == 0:
         logging.captureWarnings(True)


### PR DESCRIPTION
The JOIN command must response with first the JOIN reply (user joining the channel, sent to everyone including the sender) and followed by the name list. The name list's format is: `:{server_host} 353 {user_nick} = {channel} :{user1} {user2} {user3} ...` The `=` denotes it is a public channel.

This commit also bug fixes several leftover nasty bugs (including a `__getattr__` infinite recursion).